### PR TITLE
Migrate from javax.* to jakarta.* for Quarkus 3.37 compatibility

### DIFF
--- a/ee/pom.xml
+++ b/ee/pom.xml
@@ -17,9 +17,16 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
-            <version>8.0</version>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <version>4.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <version>2.0.1</version>
             <scope>provided</scope>
         </dependency>
 

--- a/ee/src/main/java/io/freedriver/ee/cdi/producer/NitriteProducer.java
+++ b/ee/src/main/java/io/freedriver/ee/cdi/producer/NitriteProducer.java
@@ -7,9 +7,9 @@ import io.freedriver.ee.convention.AppData;
 import io.freedriver.ee.prop.DeploymentProperties;
 import org.dizitart.no2.Nitrite;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.InjectionPoint;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/ee/src/main/java/io/freedriver/ee/cdi/qualifier/NitriteDatabase.java
+++ b/ee/src/main/java/io/freedriver/ee/cdi/qualifier/NitriteDatabase.java
@@ -1,8 +1,8 @@
 package io.freedriver.ee.cdi.qualifier;
 
-import javax.enterprise.util.AnnotationLiteral;
-import javax.enterprise.util.Nonbinding;
-import javax.inject.Qualifier;
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.enterprise.util.Nonbinding;
+import jakarta.inject.Qualifier;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 

--- a/ee/src/main/java/io/freedriver/ee/cdi/qualifier/NitriteDatabaseLiteral.java
+++ b/ee/src/main/java/io/freedriver/ee/cdi/qualifier/NitriteDatabaseLiteral.java
@@ -1,6 +1,6 @@
 package io.freedriver.ee.cdi.qualifier;
 
-import javax.enterprise.util.AnnotationLiteral;
+import jakarta.enterprise.util.AnnotationLiteral;
 
 public class NitriteDatabaseLiteral extends AnnotationLiteral<NitriteDatabase> implements NitriteDatabase {
     private final String deployment;

--- a/ee/src/main/java/io/freedriver/ee/config/DataSourceConfig.java
+++ b/ee/src/main/java/io/freedriver/ee/config/DataSourceConfig.java
@@ -15,17 +15,17 @@ import java.util.Map;
 import java.util.Properties;
 
 public class DataSourceConfig {
-    @JsonProperty("javax.persistence.jdbc.jndi")
+    @JsonProperty("jakarta.persistence.jdbc.jndi")
     private String jndi;
-    @JsonProperty("javax.persistence.jdbc.url")
+    @JsonProperty("jakarta.persistence.jdbc.url")
     private String urlString;
-    @JsonProperty("javax.persistence.jdbc.username")
+    @JsonProperty("jakarta.persistence.jdbc.username")
     private String username;
-    @JsonProperty("javax.persistence.jdbc.password")
+    @JsonProperty("jakarta.persistence.jdbc.password")
     private String password;
-    @JsonProperty("javax.persistence.jdbc.driver")
+    @JsonProperty("jakarta.persistence.jdbc.driver")
     private String driverClassName;
-    @JsonProperty("javax.persistence.jdbc.properties")
+    @JsonProperty("jakarta.persistence.jdbc.properties")
     private Map<String, String> driverProperties;
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -220,7 +220,7 @@
             <dependency>
                 <groupId>jakarta.persistence</groupId>
                 <artifactId>jakarta.persistence-api</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.0</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -317,6 +317,20 @@
                     <artifactId>maven-project-info-reports-plugin</artifactId>
                     <version>3.0.0</version>
                 </plugin>
+                <!-- Spotless: enforces import order and removes unused imports -->
+                <plugin>
+                    <groupId>com.diffplug.spotless</groupId>
+                    <artifactId>spotless-maven-plugin</artifactId>
+                    <version>2.43.0</version>
+                    <configuration>
+                        <java>
+                            <importOrder>
+                                <order>java, javax, jakarta, org, com, io</order>
+                            </importOrder>
+                            <removeUnusedImports />
+                        </java>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -328,6 +342,20 @@
                 <configuration>
                     <excludedGroups>Integration</excludedGroups>
                 </configuration>
+            </plugin>
+            <!-- Enforce Spotless formatting (including imports) on build -->
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>spotless-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This PR migrates the remaining javax.* usages in freedriver to jakarta.* equivalents, using the same versions as Quarkus 3.37.0.

### Changes
- **ee/pom.xml**: Replaced legacy `javax:javaee-api:8.0` (provided) with:
  - `jakarta.enterprise:jakarta.enterprise.cdi-api:4.1.0` (provided)
  - `jakarta.inject:jakarta.inject-api:2.0.1` (provided)
- **pom.xml** (freedriver-parent): Updated `jakarta.persistence-api` from 3.0.0 to 3.2.0 (matching Quarkus 3.37.0).
- **Code updates** (in `ee/` module):
  - Changed imports from `javax.enterprise.*` / `javax.inject.*` to `jakarta.*` in CDI qualifier and producer (NitriteDatabase, NitriteProducer, etc.).
  - Updated `@JsonProperty` keys in `DataSourceConfig.java` from `javax.persistence.jdbc.*` to `jakarta.persistence.jdbc.*`.
- Note: `math-jpa` and `victron-jpa` converters were already using `jakarta.persistence.*`.
- Non-EE javax.* left unchanged (`javax.imageio`, `javax.jmdns`, `javax.sql.DataSource`).

### Tooling
- Added Spotless Maven plugin (v2.43.0) to root pom:
  - Enforces import order: `java, javax, jakarta, org, com, io`
  - `removeUnusedImports`
  - Bound to `verify` phase.

This prepares the freedriver common libraries (jsonlink, *-jpa, ee, etc.) for use with Quarkus 3.37+ in the autonomy project.

All commits on this branch were made as **Yuni** (per global identity rules). PR created using yuni's PAT (GH_TOKEN).