### PR TITLE
Apply Spotless to enforce import order and remove unused imports

### DIFF
--- a/base/src/main/java/io/freedriver/base/util/ByteArrayBuilder.java
+++ b/base/src/main/java/io/freedriver/base/util/ByteArrayBuilder.java
@@ -1,6 +1,5 @@
 package io.freedriver.base.util;
 
-import java.nio.charset.Charset;
 import java.util.Arrays;
 
 /**

--- a/base/src/main/java/io/freedriver/base/util/EntityStream.java
+++ b/base/src/main/java/io/freedriver/base/util/EntityStream.java
@@ -1,7 +1,5 @@
 package io.freedriver.base.util;
 
-import io.freedriver.base.util.accumulator.Accumulator;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -10,6 +8,8 @@ import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
+import io.freedriver.base.util.accumulator.Accumulator;
 
 public class EntityStream<R> implements Iterator<R>, AutoCloseable {
     private final InputStream inputStream;

--- a/base/src/main/java/io/freedriver/base/util/EntityStreamWithOutput.java
+++ b/base/src/main/java/io/freedriver/base/util/EntityStreamWithOutput.java
@@ -1,11 +1,11 @@
 package io.freedriver.base.util;
 
-import io.freedriver.base.util.accumulator.Accumulator;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+
+import io.freedriver.base.util.accumulator.Accumulator;
 
 public class EntityStreamWithOutput<R> extends EntityStream<R> {
     private final OutputStream outputStream;

--- a/base/src/main/java/io/freedriver/base/util/ProcessSpawner.java
+++ b/base/src/main/java/io/freedriver/base/util/ProcessSpawner.java
@@ -1,10 +1,10 @@
 package io.freedriver.base.util;
 
+import static java.util.logging.Level.FINE;
+
 import java.io.IOException;
 import java.util.concurrent.Callable;
 import java.util.logging.Logger;
-
-import static java.util.logging.Level.FINE;
 
 public abstract class ProcessSpawner implements AutoCloseable {
     private static final Logger LOGGER = Logger.getLogger(ProcessSpawner.class.getName());

--- a/base/src/main/java/io/freedriver/base/util/ProcessUtil.java
+++ b/base/src/main/java/io/freedriver/base/util/ProcessUtil.java
@@ -1,9 +1,9 @@
 package io.freedriver.base.util;
 
-import io.freedriver.base.util.accumulator.NewlineAccumulator;
-
 import java.io.InputStream;
 import java.util.stream.Stream;
+
+import io.freedriver.base.util.accumulator.NewlineAccumulator;
 
 public class ProcessUtil {
     private ProcessUtil() {

--- a/base/src/main/java/io/freedriver/base/util/command/Command.java
+++ b/base/src/main/java/io/freedriver/base/util/command/Command.java
@@ -5,13 +5,9 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 public class Command {
     private final String invocationName;

--- a/base/src/main/java/io/freedriver/base/util/file/DirectoryProvider.java
+++ b/base/src/main/java/io/freedriver/base/util/file/DirectoryProvider.java
@@ -3,8 +3,6 @@ package io.freedriver.base.util.file;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Stream;

--- a/base/src/main/java/io/freedriver/base/util/file/ImageStream.java
+++ b/base/src/main/java/io/freedriver/base/util/file/ImageStream.java
@@ -1,6 +1,5 @@
 package io.freedriver.base.util.file;
 
-import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
@@ -9,6 +8,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
 import java.util.function.Supplier;
+import javax.imageio.ImageIO;
 
 public interface ImageStream extends Supplier<InputStream> {
     static BufferedImage toBufferedImage(Image img) {

--- a/base/src/main/java/io/freedriver/base/util/file/PathImageStream.java
+++ b/base/src/main/java/io/freedriver/base/util/file/PathImageStream.java
@@ -1,10 +1,10 @@
 package io.freedriver.base.util.file;
 
-import javax.imageio.ImageIO;
 import java.awt.*;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import javax.imageio.ImageIO;
 
 
 public class PathImageStream implements ImageStream {

--- a/base/src/main/java/io/freedriver/base/util/notify/notifysend/NotifySend.java
+++ b/base/src/main/java/io/freedriver/base/util/notify/notifysend/NotifySend.java
@@ -1,9 +1,5 @@
 package io.freedriver.base.util.notify.notifysend;
 
-import io.freedriver.base.util.file.PathImageStream;
-import io.freedriver.base.util.file.TempFile;
-import io.freedriver.base.util.notify.notifysend.hint.Hint;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -13,6 +9,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
+
+import io.freedriver.base.util.file.PathImageStream;
+import io.freedriver.base.util.file.TempFile;
+import io.freedriver.base.util.notify.notifysend.hint.Hint;
 
 public class NotifySend {
     private UrgencyLevel urgencyLevel;

--- a/base/src/test/java/io/freedriver/base/ConversionTest.java
+++ b/base/src/test/java/io/freedriver/base/ConversionTest.java
@@ -1,8 +1,8 @@
 package io.freedriver.base;
 
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
 
 public class ConversionTest {
 

--- a/base/src/test/java/io/freedriver/base/cli/ConsoleTableTest.java
+++ b/base/src/test/java/io/freedriver/base/cli/ConsoleTableTest.java
@@ -1,6 +1,7 @@
 package io.freedriver.base.cli;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -8,8 +9,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 public class ConsoleTableTest {
     Person tom = new Person(24, "Tom Janker", "44 Fourty Drive");

--- a/base/src/test/java/io/freedriver/base/command/CommandTest.java
+++ b/base/src/test/java/io/freedriver/base/command/CommandTest.java
@@ -1,18 +1,18 @@
 package io.freedriver.base.command;
 
-import io.freedriver.base.util.command.Command;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import io.freedriver.base.util.command.Command;
+import org.junit.jupiter.api.Test;
 
 public class CommandTest {
 

--- a/base/src/test/java/io/freedriver/base/util/ProcessUtilTest.java
+++ b/base/src/test/java/io/freedriver/base/util/ProcessUtilTest.java
@@ -1,8 +1,6 @@
 package io.freedriver.base.util;
 
-import io.freedriver.base.Tests;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayInputStream;
 import java.util.List;
@@ -11,7 +9,9 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import io.freedriver.base.Tests;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 
 @Tag(Tests.Integration)

--- a/base/src/test/java/io/freedriver/base/util/accumulator/AccumulatorsTest.java
+++ b/base/src/test/java/io/freedriver/base/util/accumulator/AccumulatorsTest.java
@@ -1,11 +1,11 @@
 package io.freedriver.base.util.accumulator;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.time.Duration;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 public abstract class AccumulatorsTest<R, I, A extends Accumulator<I, R>> {
     private static final Duration DEFAULT_DURATION = Duration.ofMillis(20);

--- a/base/src/test/java/io/freedriver/base/util/accumulator/ByteArrayAccumulatorsTest.java
+++ b/base/src/test/java/io/freedriver/base/util/accumulator/ByteArrayAccumulatorsTest.java
@@ -1,9 +1,5 @@
 package io.freedriver.base.util.accumulator;
 
-import io.freedriver.base.util.EntityStream;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PipedInputStream;
@@ -14,6 +10,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.stream.Stream;
+
+import io.freedriver.base.util.EntityStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 public abstract class ByteArrayAccumulatorsTest<R, A extends Accumulator<ByteArrayOutputStream, R>> extends AccumulatorsTest<R, ByteArrayOutputStream, A> {
 

--- a/base/src/test/java/io/freedriver/base/util/cache/CacheTest.java
+++ b/base/src/test/java/io/freedriver/base/util/cache/CacheTest.java
@@ -1,6 +1,9 @@
 package io.freedriver.base.util.cache;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -10,10 +13,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 public class CacheTest {
 

--- a/base/src/test/java/io/freedriver/base/util/serial/DeviceFilesTest.java
+++ b/base/src/test/java/io/freedriver/base/util/serial/DeviceFilesTest.java
@@ -1,18 +1,15 @@
 package io.freedriver.base.util.serial;
 
-import io.freedriver.base.Tests;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import io.freedriver.base.Tests;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 @Tag(Tests.Integration)
 public class DeviceFilesTest {

--- a/client/src/main/java/io/freedriver/client/RESTClient.java
+++ b/client/src/main/java/io/freedriver/client/RESTClient.java
@@ -1,14 +1,9 @@
 package io.freedriver.client;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JSR310Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.UriBuilder;
 import org.jboss.resteasy.client.jaxrs.ResteasyClient;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
-import org.jboss.resteasy.plugins.providers.jackson.ResteasyJackson2Provider;
 public class RESTClient {
 
     public static <T> T create(Class<T> klazz, UriBuilder uri) {

--- a/client/src/main/java/io/freedriver/client/jackson/InstantEpochDeserializer.java
+++ b/client/src/main/java/io/freedriver/client/jackson/InstantEpochDeserializer.java
@@ -1,12 +1,12 @@
 package io.freedriver.client.jackson;
 
+import java.io.IOException;
+import java.time.Instant;
+
 import com.fasterxml.jackson.core.JacksonException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
-
-import java.io.IOException;
-import java.time.Instant;
 
 public class InstantEpochDeserializer extends JsonDeserializer<Instant> {
     @Override

--- a/client/src/main/java/io/freedriver/client/jackson/InstantEpochSerializer.java
+++ b/client/src/main/java/io/freedriver/client/jackson/InstantEpochSerializer.java
@@ -1,11 +1,11 @@
 package io.freedriver.client.jackson;
 
+import java.io.IOException;
+import java.time.Instant;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
-
-import java.io.IOException;
-import java.time.Instant;
 
 public class InstantEpochSerializer extends JsonSerializer<Instant> {
     @Override

--- a/daly/src/main/java/io/freedriver/daly/bms/Address.java
+++ b/daly/src/main/java/io/freedriver/daly/bms/Address.java
@@ -1,11 +1,11 @@
 package io.freedriver.daly.bms;
 
-import io.freedriver.serial.stream.api.Streamable;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Objects;
 import java.util.stream.Stream;
+
+import io.freedriver.serial.stream.api.Streamable;
 
 public enum Address implements Streamable {
     BMS_MASTER(0x01),

--- a/daly/src/main/java/io/freedriver/daly/bms/DalyCommand.java
+++ b/daly/src/main/java/io/freedriver/daly/bms/DalyCommand.java
@@ -1,10 +1,10 @@
 package io.freedriver.daly.bms;
 
-import io.freedriver.serial.stream.api.Streamable;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Objects;
+
+import io.freedriver.serial.stream.api.Streamable;
 
 public enum DalyCommand implements Streamable {
     READ(0xA5),

--- a/daly/src/main/java/io/freedriver/daly/bms/Flag.java
+++ b/daly/src/main/java/io/freedriver/daly/bms/Flag.java
@@ -1,10 +1,10 @@
 package io.freedriver.daly.bms;
 
-import io.freedriver.serial.stream.api.Streamable;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Objects;
+
+import io.freedriver.serial.stream.api.Streamable;
 
 public enum Flag implements Streamable {
     START(0xDD),

--- a/daly/src/main/java/io/freedriver/daly/bms/QueryId.java
+++ b/daly/src/main/java/io/freedriver/daly/bms/QueryId.java
@@ -1,11 +1,11 @@
 package io.freedriver.daly.bms;
 
-import io.freedriver.daly.bms.exception.UnknownCommandException;
-import io.freedriver.serial.stream.api.Streamable;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.stream.Stream;
+
+import io.freedriver.daly.bms.exception.UnknownCommandException;
+import io.freedriver.serial.stream.api.Streamable;
 
 public enum QueryId implements Streamable {
     // TODO : Proper command lengths

--- a/daly/src/main/java/io/freedriver/daly/bms/Signal.java
+++ b/daly/src/main/java/io/freedriver/daly/bms/Signal.java
@@ -1,10 +1,10 @@
 package io.freedriver.daly.bms;
 
-import io.freedriver.daly.bms.checksum.CRC8;
-
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
+
+import io.freedriver.daly.bms.checksum.CRC8;
 
 public abstract class Signal {
     private Address address;

--- a/daly/src/main/java/io/freedriver/daly/bms/checksum/CRC8.java
+++ b/daly/src/main/java/io/freedriver/daly/bms/checksum/CRC8.java
@@ -1,8 +1,8 @@
 package io.freedriver.daly.bms.checksum;
 
-import io.freedriver.daly.bms.checksum.debug.CRC8Debugger;
-
 import java.util.zip.Checksum;
+
+import io.freedriver.daly.bms.checksum.debug.CRC8Debugger;
 
 /**
  * Calculate CRC-8 checksum

--- a/daly/src/main/java/io/freedriver/daly/bms/checksum/debug/CRC8Debug.java
+++ b/daly/src/main/java/io/freedriver/daly/bms/checksum/debug/CRC8Debug.java
@@ -1,6 +1,5 @@
 package io.freedriver.daly.bms.checksum.debug;
 
-import java.util.zip.Checksum;
 
 /**
  * Calculate CRC-8 checksum

--- a/daly/src/main/java/io/freedriver/daly/bms/stream/ResponseAccumlator.java
+++ b/daly/src/main/java/io/freedriver/daly/bms/stream/ResponseAccumlator.java
@@ -1,12 +1,12 @@
 package io.freedriver.daly.bms.stream;
 
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+
 import io.freedriver.base.util.accumulator.Accumulator;
 import io.freedriver.daly.bms.Address;
 import io.freedriver.daly.bms.QueryId;
 import io.freedriver.daly.bms.Response;
-
-import java.io.ByteArrayOutputStream;
-import java.util.Arrays;
 
 public class ResponseAccumlator implements Accumulator<ByteArrayOutputStream, Response> {
     /**

--- a/daly/src/test/java/io/freedriver/daly/bms/PythonTest.java
+++ b/daly/src/test/java/io/freedriver/daly/bms/PythonTest.java
@@ -1,11 +1,5 @@
 package io.freedriver.daly.bms;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.freedriver.base.Tests;
-import io.freedriver.daly.bms.checksum.debug.CRC8Steps;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -13,6 +7,12 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.Scanner;
 import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.freedriver.base.Tests;
+import io.freedriver.daly.bms.checksum.debug.CRC8Steps;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 @Tag(Tests.Integration)
 public class PythonTest {

--- a/daly/src/test/java/io/freedriver/daly/bms/RequestTest.java
+++ b/daly/src/test/java/io/freedriver/daly/bms/RequestTest.java
@@ -1,8 +1,8 @@
 package io.freedriver.daly.bms;
 
-import org.junit.jupiter.api.Test;
-
 import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
 
 public class RequestTest {
     @Test

--- a/daly/src/test/java/io/freedriver/daly/bms/checksum/CRC8DebugTest.java
+++ b/daly/src/test/java/io/freedriver/daly/bms/checksum/CRC8DebugTest.java
@@ -1,19 +1,17 @@
 package io.freedriver.daly.bms.checksum;
 
-import io.freedriver.base.Tests;
-import io.freedriver.daly.bms.ExampleResponses;
-import io.freedriver.daly.bms.PythonTest;
-import io.freedriver.daly.bms.checksum.CRC8;
-import io.freedriver.daly.bms.checksum.CRCSum;
-import io.freedriver.daly.bms.checksum.debug.CRC8Steps;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 import java.util.Random;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import io.freedriver.base.Tests;
+import io.freedriver.daly.bms.ExampleResponses;
+import io.freedriver.daly.bms.PythonTest;
+import io.freedriver.daly.bms.checksum.debug.CRC8Steps;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 @Disabled // TODO : Fix / resolve.
 public class CRC8DebugTest {

--- a/daly/src/test/java/io/freedriver/daly/bms/stream/AccumulatorTest.java
+++ b/daly/src/test/java/io/freedriver/daly/bms/stream/AccumulatorTest.java
@@ -1,18 +1,17 @@
 package io.freedriver.daly.bms.stream;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
 import io.freedriver.daly.bms.DalyCommand;
 import io.freedriver.daly.bms.ExampleResponses;
 import io.freedriver.daly.bms.Flag;
 import io.freedriver.daly.bms.Response;
-import io.freedriver.serial.stream.api.SerialEntityStream;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AccumulatorTest {
 

--- a/discovery/src/main/java/io/freedriver/discovery/Discover.java
+++ b/discovery/src/main/java/io/freedriver/discovery/Discover.java
@@ -1,10 +1,10 @@
 package io.freedriver.discovery;
 
-import io.freedriver.discovery.jmdns.JMDNSDiscovery;
-
 import java.time.Duration;
 import java.util.Set;
 import java.util.function.Predicate;
+
+import io.freedriver.discovery.jmdns.JMDNSDiscovery;
 
 public class Discover {
     private static final Discovery DISCOVERY = new JMDNSDiscovery();

--- a/discovery/src/main/java/io/freedriver/discovery/jmdns/JMDNSDiscovery.java
+++ b/discovery/src/main/java/io/freedriver/discovery/jmdns/JMDNSDiscovery.java
@@ -1,12 +1,5 @@
 package io.freedriver.discovery.jmdns;
 
-import io.freedriver.discovery.DiscoveredService;
-import io.freedriver.discovery.Discovery;
-import io.freedriver.discovery.ServiceType;
-
-import javax.jmdns.JmDNS;
-import javax.jmdns.ServiceEvent;
-import javax.jmdns.ServiceListener;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
@@ -31,6 +24,13 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import javax.jmdns.JmDNS;
+import javax.jmdns.ServiceEvent;
+import javax.jmdns.ServiceListener;
+
+import io.freedriver.discovery.DiscoveredService;
+import io.freedriver.discovery.Discovery;
+import io.freedriver.discovery.ServiceType;
 
 public class JMDNSDiscovery implements Discovery {
     private static final Logger LOGGER = Logger.getLogger(JMDNSDiscovery.class.getName());

--- a/discovery/src/main/java/io/freedriver/discovery/jmdns/ServiceDescriptor.java
+++ b/discovery/src/main/java/io/freedriver/discovery/jmdns/ServiceDescriptor.java
@@ -1,10 +1,10 @@
 package io.freedriver.discovery.jmdns;
 
+import javax.jmdns.ServiceInfo;
+
 import io.freedriver.discovery.ApplicationProtocol;
 import io.freedriver.discovery.Scope;
 import io.freedriver.discovery.TransportProtocol;
-
-import javax.jmdns.ServiceInfo;
 
 public class ServiceDescriptor implements JMDNSAspect<ServiceInfo> {
     private TransportProtocol transportProtocol;

--- a/discovery/src/test/java/io/freedriver/discovery/JMDNSDiscoveryTest.java
+++ b/discovery/src/test/java/io/freedriver/discovery/JMDNSDiscoveryTest.java
@@ -1,9 +1,9 @@
 package io.freedriver.discovery;
 
+import java.net.Inet4Address;
+
 import io.freedriver.discovery.jmdns.JMDNSDiscovery;
 import org.junit.jupiter.api.Test;
-
-import java.net.Inet4Address;
 
 public class JMDNSDiscoveryTest {
     @Test

--- a/ee/src/main/java/io/freedriver/ee/cdi/producer/NitriteProducer.java
+++ b/ee/src/main/java/io/freedriver/ee/cdi/producer/NitriteProducer.java
@@ -1,15 +1,5 @@
 package io.freedriver.ee.cdi.producer;
 
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import io.freedriver.ee.cdi.qualifier.NitriteDatabase;
-import io.freedriver.ee.cdi.qualifier.NitriteDatabaseLiteral;
-import io.freedriver.ee.convention.AppData;
-import io.freedriver.ee.prop.DeploymentProperties;
-import org.dizitart.no2.Nitrite;
-
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Produces;
-import jakarta.enterprise.inject.spi.InjectionPoint;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -19,6 +9,16 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.freedriver.ee.cdi.qualifier.NitriteDatabase;
+import io.freedriver.ee.cdi.qualifier.NitriteDatabaseLiteral;
+import io.freedriver.ee.convention.AppData;
+import io.freedriver.ee.prop.DeploymentProperties;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.InjectionPoint;
+import org.dizitart.no2.Nitrite;
 
 @ApplicationScoped
 public class NitriteProducer {

--- a/ee/src/main/java/io/freedriver/ee/cdi/qualifier/NitriteDatabase.java
+++ b/ee/src/main/java/io/freedriver/ee/cdi/qualifier/NitriteDatabase.java
@@ -1,10 +1,11 @@
 package io.freedriver.ee.cdi.qualifier;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
 import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.enterprise.util.Nonbinding;
 import jakarta.inject.Qualifier;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)

--- a/ee/src/main/java/io/freedriver/ee/config/DataSourceConfig.java
+++ b/ee/src/main/java/io/freedriver/ee/config/DataSourceConfig.java
@@ -1,9 +1,5 @@
 package io.freedriver.ee.config;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-import javax.sql.DataSource;
 import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -13,6 +9,10 @@ import java.sql.Driver;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
+import javax.sql.DataSource;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class DataSourceConfig {
     @JsonProperty("jakarta.persistence.jdbc.jndi")

--- a/ee/src/main/java/io/freedriver/ee/config/DataSourceConfigDataSource.java
+++ b/ee/src/main/java/io/freedriver/ee/config/DataSourceConfigDataSource.java
@@ -1,6 +1,5 @@
 package io.freedriver.ee.config;
 
-import javax.sql.DataSource;
 import java.io.PrintWriter;
 import java.net.URI;
 import java.sql.Connection;
@@ -8,6 +7,7 @@ import java.sql.Driver;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.logging.Logger;
+import javax.sql.DataSource;
 
 public class DataSourceConfigDataSource implements DataSource {
     private final Logger LOGGER = Logger.getLogger(DataSourceConfigDataSource.class.getName());

--- a/ee/src/main/java/io/freedriver/ee/convention/AppData.java
+++ b/ee/src/main/java/io/freedriver/ee/convention/AppData.java
@@ -1,9 +1,5 @@
 package io.freedriver.ee.convention;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.freedriver.ee.config.DataSourceConfig;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -14,6 +10,10 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.freedriver.ee.config.DataSourceConfig;
 
 public class AppData {
     private static final Logger LOGGER = Logger.getLogger(AppData.class.getName());

--- a/electrodacus/src/main/java/io/freedriver/electrodacus/sbms/SBMS0Finder.java
+++ b/electrodacus/src/main/java/io/freedriver/electrodacus/sbms/SBMS0Finder.java
@@ -1,23 +1,20 @@
 package io.freedriver.electrodacus.sbms;
 
-import io.freedriver.serial.JSSCSerialResource;
-import io.freedriver.serial.api.SerialPortResourceSupplier;
-import io.freedriver.serial.api.SerialResource;
-import io.freedriver.serial.api.params.BaudRate;
-import io.freedriver.serial.api.params.BaudRates;
-import io.freedriver.serial.api.params.SerialParams;
-import io.freedriver.serial.stream.api.SerialEntityStream;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import io.freedriver.serial.JSSCSerialResource;
+import io.freedriver.serial.api.params.BaudRate;
+import io.freedriver.serial.api.params.BaudRates;
+import io.freedriver.serial.api.params.SerialParams;
+import io.freedriver.serial.stream.api.SerialEntityStream;
 
 public class SBMS0Finder {
     private static final Logger LOGGER = Logger.getLogger(SBMS0Finder.class.getName());

--- a/electrodacus/src/main/java/io/freedriver/electrodacus/sbms/SBMSFieldSetter.java
+++ b/electrodacus/src/main/java/io/freedriver/electrodacus/sbms/SBMSFieldSetter.java
@@ -1,18 +1,18 @@
 package io.freedriver.electrodacus.sbms;
 
-import io.freedriver.math.UnitPrefix;
-import io.freedriver.math.measurement.types.electrical.Current;
-import io.freedriver.math.measurement.types.electrical.Potential;
-import io.freedriver.math.measurement.types.thermo.Temperature;
-import io.freedriver.math.measurement.units.TemperatureScale;
-import io.freedriver.math.number.ScaledNumber;
-
 import java.time.Instant;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
+
+import io.freedriver.math.UnitPrefix;
+import io.freedriver.math.measurement.types.electrical.Current;
+import io.freedriver.math.measurement.types.electrical.Potential;
+import io.freedriver.math.measurement.types.thermo.Temperature;
+import io.freedriver.math.measurement.units.TemperatureScale;
+import io.freedriver.math.number.ScaledNumber;
 
 /**
  * The job of this class is to hydrate SBMSMessage objects with the data from the SBMS0.

--- a/electrodacus/src/main/java/io/freedriver/electrodacus/sbms/SBMSMessage.java
+++ b/electrodacus/src/main/java/io/freedriver/electrodacus/sbms/SBMSMessage.java
@@ -1,14 +1,14 @@
 package io.freedriver.electrodacus.sbms;
 
-import io.freedriver.math.measurement.types.electrical.Current;
-import io.freedriver.math.measurement.types.electrical.Potential;
-import io.freedriver.math.measurement.types.thermo.Temperature;
-
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+
+import io.freedriver.math.measurement.types.electrical.Current;
+import io.freedriver.math.measurement.types.electrical.Potential;
+import io.freedriver.math.measurement.types.thermo.Temperature;
 
 public class SBMSMessage {
     private Path path;

--- a/electrodacus/src/main/java/io/freedriver/electrodacus/sbms/SBMSMessageAccumulator.java
+++ b/electrodacus/src/main/java/io/freedriver/electrodacus/sbms/SBMSMessageAccumulator.java
@@ -1,9 +1,9 @@
 package io.freedriver.electrodacus.sbms;
 
-import io.freedriver.base.util.accumulator.ByteArrayAccumulator;
-
 import java.io.ByteArrayOutputStream;
 import java.nio.file.Path;
+
+import io.freedriver.base.util.accumulator.ByteArrayAccumulator;
 
 public class SBMSMessageAccumulator extends ByteArrayAccumulator<SBMSMessage> {
     private final Path path;

--- a/electrodacus/src/test/java/io/freedriver/electrodacus/sbms/ErrorCodeTest.java
+++ b/electrodacus/src/test/java/io/freedriver/electrodacus/sbms/ErrorCodeTest.java
@@ -1,13 +1,13 @@
 package io.freedriver.electrodacus.sbms;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 public class ErrorCodeTest {
 

--- a/genetry-kibana/src/main/java/io/freedriver/generty/kibana/GenetryTrayIcon.java
+++ b/genetry-kibana/src/main/java/io/freedriver/generty/kibana/GenetryTrayIcon.java
@@ -1,9 +1,6 @@
 package io.freedriver.generty.kibana;
 
 import java.awt.*;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
 import java.net.URL;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/genetry-kibana/src/main/java/io/freedriver/generty/kibana/InverterBridge.java
+++ b/genetry-kibana/src/main/java/io/freedriver/generty/kibana/InverterBridge.java
@@ -1,20 +1,5 @@
 package io.freedriver.generty.kibana;
 
-import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import co.elastic.clients.elasticsearch.core.IndexRequest;
-import co.elastic.clients.json.jackson.JacksonJsonpMapper;
-import co.elastic.clients.transport.ElasticsearchTransport;
-import co.elastic.clients.transport.rest_client.RestClientTransport;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import io.freedriver.discovery.DiscoveredService;
-import io.freedriver.generty.InverterFinder;
-import io.freedriver.generty.model.Statsjson;
-import org.apache.http.HttpHost;
-import org.elasticsearch.client.RestClient;
-
 import java.awt.*;
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,6 +17,21 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.IndexRequest;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.freedriver.discovery.DiscoveredService;
+import io.freedriver.generty.InverterFinder;
+import io.freedriver.generty.model.Statsjson;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
 
 
 public class InverterBridge {

--- a/genetry-kibana/src/main/java/io/freedriver/generty/kibana/KibanaStats.java
+++ b/genetry-kibana/src/main/java/io/freedriver/generty/kibana/KibanaStats.java
@@ -1,5 +1,13 @@
 package io.freedriver.generty.kibana;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.freedriver.generty.model.FansSection;
 import io.freedriver.generty.model.InputsSection;
@@ -8,14 +16,6 @@ import io.freedriver.generty.model.SetupSection;
 import io.freedriver.generty.model.StatsSection;
 import io.freedriver.generty.model.Statsjson;
 import io.freedriver.generty.model.TempsSection;
-
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.time.Instant;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * A Flattened version of stats.json to make it easier for kibana to visualize.

--- a/genetry/src/main/java/io/freedriver/generty/InverterFinder.java
+++ b/genetry/src/main/java/io/freedriver/generty/InverterFinder.java
@@ -1,12 +1,12 @@
 package io.freedriver.generty;
 
-import io.freedriver.discovery.Discover;
-import io.freedriver.discovery.DiscoveredService;
-import io.freedriver.discovery.ServiceType;
-
 import java.time.Duration;
 import java.util.Objects;
 import java.util.Set;
+
+import io.freedriver.discovery.Discover;
+import io.freedriver.discovery.DiscoveredService;
+import io.freedriver.discovery.ServiceType;
 
 public class InverterFinder {
     private static final String INVERTER_NAME = "Genetry Solar Inverter Local Webserver";

--- a/genetry/src/main/java/io/freedriver/generty/model/FansSection.java
+++ b/genetry/src/main/java/io/freedriver/generty/model/FansSection.java
@@ -1,9 +1,9 @@
 package io.freedriver.generty.model;
 
+import java.math.BigDecimal;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import java.math.BigDecimal;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class FansSection {

--- a/genetry/src/main/java/io/freedriver/generty/model/InputsSection.java
+++ b/genetry/src/main/java/io/freedriver/generty/model/InputsSection.java
@@ -1,9 +1,9 @@
 package io.freedriver.generty.model;
 
+import java.math.BigDecimal;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSetter;
-
-import java.math.BigDecimal;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class InputsSection {

--- a/genetry/src/main/java/io/freedriver/generty/model/OutputsSection.java
+++ b/genetry/src/main/java/io/freedriver/generty/model/OutputsSection.java
@@ -1,8 +1,8 @@
 package io.freedriver.generty.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
 import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class OutputsSection {

--- a/genetry/src/main/java/io/freedriver/generty/model/SetupSection.java
+++ b/genetry/src/main/java/io/freedriver/generty/model/SetupSection.java
@@ -1,9 +1,9 @@
 package io.freedriver.generty.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
 import java.math.BigDecimal;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SetupSection {

--- a/genetry/src/main/java/io/freedriver/generty/model/StatsSection.java
+++ b/genetry/src/main/java/io/freedriver/generty/model/StatsSection.java
@@ -1,9 +1,9 @@
 package io.freedriver.generty.model;
 
+import java.math.BigDecimal;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import java.math.BigDecimal;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StatsSection {

--- a/genetry/src/main/java/io/freedriver/generty/model/TempsSection.java
+++ b/genetry/src/main/java/io/freedriver/generty/model/TempsSection.java
@@ -1,9 +1,9 @@
 package io.freedriver.generty.model;
 
+import java.math.BigDecimal;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import java.math.BigDecimal;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TempsSection {

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/ConcurrentConnector.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/ConcurrentConnector.java
@@ -1,10 +1,10 @@
 package io.freedriver.jsonlink;
 
-import io.freedriver.jsonlink.jackson.schema.v1.Request;
-import io.freedriver.jsonlink.jackson.schema.v1.Response;
-
 import java.time.Duration;
 import java.util.UUID;
+
+import io.freedriver.jsonlink.jackson.schema.v1.Request;
+import io.freedriver.jsonlink.jackson.schema.v1.Response;
 
 /**
  * Connector delegator that forces synchronization across all methods.

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/Connector.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/Connector.java
@@ -1,10 +1,6 @@
 package io.freedriver.jsonlink;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.freedriver.jsonlink.jackson.JsonLinkModule;
-import io.freedriver.jsonlink.jackson.schema.v1.Request;
-import io.freedriver.jsonlink.jackson.schema.v1.Response;
+import static java.time.temporal.ChronoUnit.SECONDS;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -13,7 +9,11 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.logging.Logger;
 
-import static java.time.temporal.ChronoUnit.SECONDS;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.freedriver.jsonlink.jackson.JsonLinkModule;
+import io.freedriver.jsonlink.jackson.schema.v1.Request;
+import io.freedriver.jsonlink.jackson.schema.v1.Response;
 
 public interface Connector extends AutoCloseable {
     Logger LOGGER = Logger.getLogger(Connector.class.getName());

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/Connectors.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/Connectors.java
@@ -1,9 +1,5 @@
 package io.freedriver.jsonlink;
 
-import io.freedriver.serial.JSSCSerialResource;
-import io.freedriver.serial.api.SerialResource;
-import io.freedriver.serial.api.params.SerialParams;
-
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashSet;
@@ -20,6 +16,10 @@ import java.util.function.Function;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import io.freedriver.serial.JSSCSerialResource;
+import io.freedriver.serial.api.SerialResource;
+import io.freedriver.serial.api.params.SerialParams;
 
 public final class Connectors {
     private static final Logger LOGGER = Logger.getLogger(Connectors.class.getName());

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/FailedConnector.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/FailedConnector.java
@@ -1,11 +1,11 @@
 package io.freedriver.jsonlink;
 
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static java.time.temporal.ChronoUnit.SECONDS;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
-
-import static java.time.temporal.ChronoUnit.MINUTES;
-import static java.time.temporal.ChronoUnit.SECONDS;
 
 public class FailedConnector {
     private static final Duration DEFAULT_DURATION = Duration.of(5, MINUTES);

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/ResponseAccumulator.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/ResponseAccumulator.java
@@ -1,14 +1,14 @@
 package io.freedriver.jsonlink;
 
-import io.freedriver.base.util.accumulator.Accumulator;
-import io.freedriver.jsonlink.jackson.schema.v1.Response;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+
+import io.freedriver.base.util.accumulator.Accumulator;
+import io.freedriver.jsonlink.jackson.schema.v1.Response;
 
 public class ResponseAccumulator implements Accumulator<ByteArrayOutputStream, Response> {
 

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/SerialConnector.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/SerialConnector.java
@@ -1,11 +1,6 @@
 package io.freedriver.jsonlink;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import io.freedriver.jsonlink.jackson.schema.v1.Request;
-import io.freedriver.jsonlink.jackson.schema.v1.Response;
-import io.freedriver.serial.api.SerialResource;
-import io.freedriver.serial.api.exception.SerialResourceException;
-import io.freedriver.serial.stream.api.SerialEntityStream;
+import static java.time.temporal.ChronoUnit.MINUTES;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -23,7 +18,12 @@ import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static java.time.temporal.ChronoUnit.MINUTES;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.freedriver.jsonlink.jackson.schema.v1.Request;
+import io.freedriver.jsonlink.jackson.schema.v1.Response;
+import io.freedriver.serial.api.SerialResource;
+import io.freedriver.serial.api.exception.SerialResourceException;
+import io.freedriver.serial.stream.api.SerialEntityStream;
 
 public class SerialConnector implements Connector, AutoCloseable {
     private static final Logger LOGGER = Logger.getLogger(SerialConnector.class.getName());

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/config/ConfigMapper.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/config/ConfigMapper.java
@@ -1,10 +1,10 @@
 package io.freedriver.jsonlink.config;
 
+import java.util.logging.Logger;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import io.freedriver.jsonlink.jackson.JsonLinkModule;
-
-import java.util.logging.Logger;
 
 public interface ConfigMapper {
     ObjectMapper MAPPER = new ObjectMapper().registerModule(new JsonLinkModule()).enable(SerializationFeature.INDENT_OUTPUT);

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/config/ConnectorConfig.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/config/ConnectorConfig.java
@@ -1,8 +1,6 @@
 package io.freedriver.jsonlink.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import io.freedriver.jsonlink.jackson.JsonLinkModule;
+import static io.freedriver.jsonlink.config.ConfigMapper.MAPPER;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -13,7 +11,6 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static io.freedriver.jsonlink.config.ConfigMapper.MAPPER;
 
 public class ConnectorConfig {
     private static final Path CONFIG_PATH = Paths.get(System.getProperty("user.home"), ".config/jsonlink");

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/config/Mapping.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/config/Mapping.java
@@ -1,14 +1,14 @@
 package io.freedriver.jsonlink.config;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.freedriver.jsonlink.jackson.schema.v1.Identifier;
-
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.freedriver.jsonlink.jackson.schema.v1.Identifier;
 
 public class Mapping {
     private UUID connectorId;

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/config/Mappings.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/config/Mappings.java
@@ -1,11 +1,11 @@
 package io.freedriver.jsonlink.config;
 
-import io.freedriver.jsonlink.config.v2.Appliance;
-
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import io.freedriver.jsonlink.config.v2.Appliance;
 
 public class Mappings extends ConfigFile implements Migration<io.freedriver.jsonlink.config.v2.Mappings> {
     private Set<Mapping> mappings = new HashSet<>();

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/config/PinName.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/config/PinName.java
@@ -1,11 +1,11 @@
 package io.freedriver.jsonlink.config;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.freedriver.jsonlink.jackson.schema.v1.Identifier;
-
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.freedriver.jsonlink.jackson.schema.v1.Identifier;
 
 public class PinName {
     private Identifier pinNumber;

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/config/v2/AnalogSensor.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/config/v2/AnalogSensor.java
@@ -1,10 +1,10 @@
 package io.freedriver.jsonlink.config.v2;
 
+import java.util.Objects;
+
 import io.freedriver.jsonlink.jackson.schema.v1.AnalogRead;
 import io.freedriver.jsonlink.jackson.schema.v1.Identifier;
 import io.freedriver.jsonlink.jackson.schema.v1.Request;
-
-import java.util.Objects;
 
 public class AnalogSensor {
     private String name;

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/config/v2/Appliance.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/config/v2/Appliance.java
@@ -1,12 +1,12 @@
 package io.freedriver.jsonlink.config.v2;
 
-import io.freedriver.jsonlink.jackson.schema.v1.Identifier;
-
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+
+import io.freedriver.jsonlink.jackson.schema.v1.Identifier;
 
 public class Appliance {
     private Identifier identifier;

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/config/v2/Mapping.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/config/v2/Mapping.java
@@ -1,12 +1,5 @@
 package io.freedriver.jsonlink.config.v2;
 
-import io.freedriver.jsonlink.config.Migration;
-import io.freedriver.jsonlink.config.v3.ApplianceDescriptor;
-import io.freedriver.jsonlink.config.v3.Mappings;
-import io.freedriver.jsonlink.config.v3.EventDescriptor;
-import io.freedriver.jsonlink.config.v3.JoystickButtonEvent;
-import io.freedriver.jsonlink.config.v3.ToggleAction;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -16,6 +9,13 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import io.freedriver.jsonlink.config.Migration;
+import io.freedriver.jsonlink.config.v3.ApplianceDescriptor;
+import io.freedriver.jsonlink.config.v3.EventDescriptor;
+import io.freedriver.jsonlink.config.v3.JoystickButtonEvent;
+import io.freedriver.jsonlink.config.v3.Mappings;
+import io.freedriver.jsonlink.config.v3.ToggleAction;
 
 @Deprecated
 public class Mapping implements Migration<Mappings> {

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/config/v2/Mappings.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/config/v2/Mappings.java
@@ -1,11 +1,11 @@
 package io.freedriver.jsonlink.config.v2;
 
-import io.freedriver.jsonlink.config.ConfigFile;
-
 import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+
+import io.freedriver.jsonlink.config.ConfigFile;
 
 @Deprecated
 public class Mappings extends ConfigFile {

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/config/v3/Appliance.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/config/v3/Appliance.java
@@ -1,13 +1,12 @@
 package io.freedriver.jsonlink.config.v3;
 
-import io.freedriver.jsonlink.config.ConfigFile;
-import io.freedriver.jsonlink.jackson.schema.v1.Identifier;
-
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+
+import io.freedriver.jsonlink.jackson.schema.v1.Identifier;
 
 public class Appliance {
     private UUID connectorId;

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/config/v3/Descriptor.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/config/v3/Descriptor.java
@@ -1,8 +1,8 @@
 package io.freedriver.jsonlink.config.v3;
 
-import com.fasterxml.jackson.annotation.JsonValue;
-
 import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonValue;
 
 public abstract class Descriptor {
     private final String value;

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/config/v3/Mappings.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/config/v3/Mappings.java
@@ -1,11 +1,5 @@
 package io.freedriver.jsonlink.config.v3;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import io.freedriver.base.util.file.DirectoryProviders;
-import io.freedriver.base.util.file.PathProvider;
-import io.freedriver.jsonlink.Connector;
-import io.freedriver.jsonlink.config.ConfigMapper;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
@@ -14,6 +8,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.logging.Level;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.freedriver.base.util.file.DirectoryProviders;
+import io.freedriver.base.util.file.PathProvider;
+import io.freedriver.jsonlink.config.ConfigMapper;
 
 public class Mappings {
 

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/config/v3/SensorMapping.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/config/v3/SensorMapping.java
@@ -1,15 +1,12 @@
 package io.freedriver.jsonlink.config.v3;
 
-import io.freedriver.jsonlink.config.v2.AnalogAlert;
-import io.freedriver.jsonlink.config.v2.AnalogSensor;
-import io.freedriver.jsonlink.config.v2.Appliance;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
+
+import io.freedriver.jsonlink.config.v2.AnalogAlert;
+import io.freedriver.jsonlink.config.v2.AnalogSensor;
 
 public class SensorMapping  {
     private Set<AnalogSensor> analogSensors = new HashSet<>();

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/jackson/AnalogPinNumberKeyDeserializer.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/jackson/AnalogPinNumberKeyDeserializer.java
@@ -1,10 +1,10 @@
 package io.freedriver.jsonlink.jackson;
 
+import java.io.IOException;
+
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.KeyDeserializer;
 import io.freedriver.jsonlink.jackson.schema.v1.Identifier;
-
-import java.io.IOException;
 
 public class AnalogPinNumberKeyDeserializer extends KeyDeserializer {
     @Override

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/jackson/AnalogPinNumberSerializer.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/jackson/AnalogPinNumberSerializer.java
@@ -1,11 +1,11 @@
 package io.freedriver.jsonlink.jackson;
 
+import java.io.IOException;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import io.freedriver.jsonlink.jackson.schema.v1.Identifier;
-
-import java.io.IOException;
 
 public class AnalogPinNumberSerializer extends JsonSerializer<Identifier> {
 

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/jackson/DigitalStateSerializer.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/jackson/DigitalStateSerializer.java
@@ -1,11 +1,11 @@
 package io.freedriver.jsonlink.jackson;
 
+import java.io.IOException;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import io.freedriver.jsonlink.jackson.schema.v1.DigitalState;
-
-import java.io.IOException;
 
 public class DigitalStateSerializer extends JsonSerializer<DigitalState> {
     @Override

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/jackson/ModeSerializer.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/jackson/ModeSerializer.java
@@ -1,11 +1,11 @@
 package io.freedriver.jsonlink.jackson;
 
+import java.io.IOException;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import io.freedriver.jsonlink.jackson.schema.v1.Mode;
-
-import java.io.IOException;
 
 public class ModeSerializer extends JsonSerializer<Mode> {
     @Override

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/jackson/PinNumberKeyDeserializer.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/jackson/PinNumberKeyDeserializer.java
@@ -1,10 +1,10 @@
 package io.freedriver.jsonlink.jackson;
 
+import java.io.IOException;
+
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.KeyDeserializer;
 import io.freedriver.jsonlink.jackson.schema.v1.Identifier;
-
-import java.io.IOException;
 
 public class PinNumberKeyDeserializer extends KeyDeserializer {
     @Override

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/jackson/PinNumberSerializer.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/jackson/PinNumberSerializer.java
@@ -1,11 +1,11 @@
 package io.freedriver.jsonlink.jackson;
 
+import java.io.IOException;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import io.freedriver.jsonlink.jackson.schema.v1.Identifier;
-
-import java.io.IOException;
 
 public class PinNumberSerializer extends JsonSerializer<Identifier> {
 

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/jackson/schema/base/Version.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/jackson/schema/base/Version.java
@@ -1,11 +1,11 @@
 package io.freedriver.jsonlink.jackson.schema.base;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
-
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 public class Version {
     public static final String DELIMITER = "\\.";

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/jackson/schema/v1/Identifier.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/jackson/schema/v1/Identifier.java
@@ -1,11 +1,11 @@
 package io.freedriver.jsonlink.jackson.schema.v1;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.freedriver.jsonlink.jackson.PinNumberKeyDeserializer;
 import io.freedriver.jsonlink.jackson.PinNumberSerializer;
-
-import java.util.Objects;
 
 @JsonSerialize(using = PinNumberSerializer.class)
 @JsonDeserialize(keyUsing = PinNumberKeyDeserializer.class)

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/jackson/schema/v1/Request.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/jackson/schema/v1/Request.java
@@ -1,14 +1,14 @@
 package io.freedriver.jsonlink.jackson.schema.v1;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.freedriver.jsonlink.Connector;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.freedriver.jsonlink.Connector;
 
 public class Request {
     private UUID uuid;

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/jackson/schema/v1/Response.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/jackson/schema/v1/Response.java
@@ -1,8 +1,5 @@
 package io.freedriver.jsonlink.jackson.schema.v1;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.freedriver.jsonlink.jackson.schema.base.BaseResponse;
-
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -10,6 +7,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.freedriver.jsonlink.jackson.schema.base.BaseResponse;
 
 public class Response extends BaseResponse {
     private UUID uuid;

--- a/jsonlink/src/main/java/io/freedriver/jsonlink/pin/PinCoordinate.java
+++ b/jsonlink/src/main/java/io/freedriver/jsonlink/pin/PinCoordinate.java
@@ -1,9 +1,9 @@
 package io.freedriver.jsonlink.pin;
 
-import io.freedriver.jsonlink.jackson.schema.v1.Identifier;
-
 import java.util.Objects;
 import java.util.UUID;
+
+import io.freedriver.jsonlink.jackson.schema.v1.Identifier;
 
 /**
  * Represents a GPIO pin on a board with a known id.

--- a/jsonlink/src/test/java/io/freedriver/jsonlink/MarshallingTest.java
+++ b/jsonlink/src/test/java/io/freedriver/jsonlink/MarshallingTest.java
@@ -1,14 +1,14 @@
 package io.freedriver.jsonlink;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.freedriver.jsonlink.jackson.JsonLinkModule;
 import io.freedriver.jsonlink.jackson.schema.base.BaseResponse;
 import io.freedriver.jsonlink.jackson.schema.base.Version;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class MarshallingTest {
 

--- a/math-jpa/src/main/java/io/freedriver/math/jpa/converter/measurement/CurrentConverter.java
+++ b/math-jpa/src/main/java/io/freedriver/math/jpa/converter/measurement/CurrentConverter.java
@@ -1,12 +1,12 @@
 package io.freedriver.math.jpa.converter.measurement;
 
+import java.math.BigDecimal;
+
 import io.freedriver.math.UnitPrefix;
 import io.freedriver.math.measurement.types.electrical.Current;
 import io.freedriver.math.number.ScaledNumber;
-
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
-import java.math.BigDecimal;
 
 @Converter(autoApply = true)
 public class CurrentConverter extends MeasurementConverter<Current> implements AttributeConverter<Current, BigDecimal> {

--- a/math-jpa/src/main/java/io/freedriver/math/jpa/converter/measurement/EnergyConverter.java
+++ b/math-jpa/src/main/java/io/freedriver/math/jpa/converter/measurement/EnergyConverter.java
@@ -1,11 +1,11 @@
 package io.freedriver.math.jpa.converter.measurement;
 
+import java.math.BigDecimal;
+
 import io.freedriver.math.UnitPrefix;
 import io.freedriver.math.measurement.types.electrical.Energy;
 import io.freedriver.math.number.ScaledNumber;
-
 import jakarta.persistence.Converter;
-import java.math.BigDecimal;
 
 @Converter(autoApply = true)
 public class EnergyConverter extends TemporalMeasurementConverter<Energy> {

--- a/math-jpa/src/main/java/io/freedriver/math/jpa/converter/measurement/MeasurementConverter.java
+++ b/math-jpa/src/main/java/io/freedriver/math/jpa/converter/measurement/MeasurementConverter.java
@@ -1,10 +1,10 @@
 package io.freedriver.math.jpa.converter.measurement;
 
+import java.math.BigDecimal;
+
 import io.freedriver.math.UnitPrefix;
 import io.freedriver.math.measurement.types.Measurement;
-
 import jakarta.persistence.AttributeConverter;
-import java.math.BigDecimal;
 
 public abstract class MeasurementConverter<M extends Measurement<M>> implements AttributeConverter<M, BigDecimal> {
     protected abstract M construct(BigDecimal value, UnitPrefix unitPrefix);

--- a/math-jpa/src/main/java/io/freedriver/math/jpa/converter/measurement/PotentialConverter.java
+++ b/math-jpa/src/main/java/io/freedriver/math/jpa/converter/measurement/PotentialConverter.java
@@ -1,11 +1,11 @@
 package io.freedriver.math.jpa.converter.measurement;
 
+import java.math.BigDecimal;
+
 import io.freedriver.math.UnitPrefix;
 import io.freedriver.math.measurement.types.electrical.Potential;
 import io.freedriver.math.number.ScaledNumber;
-
 import jakarta.persistence.Converter;
-import java.math.BigDecimal;
 
 @Converter(autoApply = true)
 public class PotentialConverter extends MeasurementConverter<Potential> {

--- a/math-jpa/src/main/java/io/freedriver/math/jpa/converter/measurement/PowerConverter.java
+++ b/math-jpa/src/main/java/io/freedriver/math/jpa/converter/measurement/PowerConverter.java
@@ -1,11 +1,11 @@
 package io.freedriver.math.jpa.converter.measurement;
 
+import java.math.BigDecimal;
+
 import io.freedriver.math.UnitPrefix;
 import io.freedriver.math.measurement.types.electrical.Power;
 import io.freedriver.math.number.ScaledNumber;
-
 import jakarta.persistence.Converter;
-import java.math.BigDecimal;
 
 @Converter(autoApply = true)
 public class PowerConverter extends MeasurementConverter<Power> {

--- a/math-jpa/src/main/java/io/freedriver/math/jpa/converter/measurement/StringMeasurementConverter.java
+++ b/math-jpa/src/main/java/io/freedriver/math/jpa/converter/measurement/StringMeasurementConverter.java
@@ -1,15 +1,15 @@
 package io.freedriver.math.jpa.converter.measurement;
 
-import io.freedriver.math.UnitPrefix;
-import io.freedriver.math.measurement.types.Measurement;
-import io.freedriver.math.measurement.units.SIElectricalUnit;
-
-import jakarta.persistence.AttributeConverter;
 import java.math.BigDecimal;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import io.freedriver.math.UnitPrefix;
+import io.freedriver.math.measurement.types.Measurement;
+import io.freedriver.math.measurement.units.SIElectricalUnit;
+import jakarta.persistence.AttributeConverter;
 
 public abstract class StringMeasurementConverter<M extends Measurement<M>> implements AttributeConverter<M, String> {
     protected static final String VALUE_GROUP = "value";

--- a/math-jpa/src/main/java/io/freedriver/math/jpa/converter/measurement/StringTemporalMeasurementConverter.java
+++ b/math-jpa/src/main/java/io/freedriver/math/jpa/converter/measurement/StringTemporalMeasurementConverter.java
@@ -1,13 +1,13 @@
 package io.freedriver.math.jpa.converter.measurement;
 
-import io.freedriver.math.TemporalUnit;
-import io.freedriver.math.UnitPrefix;
-import io.freedriver.math.measurement.types.TemporalMeasurement;
-
 import java.math.BigDecimal;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import io.freedriver.math.TemporalUnit;
+import io.freedriver.math.UnitPrefix;
+import io.freedriver.math.measurement.types.TemporalMeasurement;
 
 public abstract class StringTemporalMeasurementConverter<TM extends TemporalMeasurement<TM>> extends StringMeasurementConverter<TM> {
     protected static final String TEMPORAL_GROUP = "temporal";

--- a/math-jpa/src/main/java/io/freedriver/math/jpa/converter/measurement/TemperatureConverter.java
+++ b/math-jpa/src/main/java/io/freedriver/math/jpa/converter/measurement/TemperatureConverter.java
@@ -1,13 +1,13 @@
 package io.freedriver.math.jpa.converter.measurement;
 
+import java.math.BigDecimal;
+
 import io.freedriver.math.UnitPrefix;
 import io.freedriver.math.measurement.types.thermo.Temperature;
 import io.freedriver.math.measurement.units.TemperatureScale;
 import io.freedriver.math.number.ScaledNumber;
-
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
-import java.math.BigDecimal;
 
 @Converter(autoApply = true)
 public class TemperatureConverter extends MeasurementConverter<Temperature> implements AttributeConverter<Temperature, BigDecimal> {

--- a/math-jpa/src/main/java/io/freedriver/math/jpa/converter/measurement/TemporalMeasurementConverter.java
+++ b/math-jpa/src/main/java/io/freedriver/math/jpa/converter/measurement/TemporalMeasurementConverter.java
@@ -1,9 +1,9 @@
 package io.freedriver.math.jpa.converter.measurement;
 
+import java.math.BigDecimal;
+
 import io.freedriver.math.UnitPrefix;
 import io.freedriver.math.measurement.types.TemporalMeasurement;
-
-import java.math.BigDecimal;
 
 public abstract class TemporalMeasurementConverter<TM extends TemporalMeasurement<TM>> extends MeasurementConverter<TM> {
     @Override

--- a/math-jpa/src/test/java/io/freedriver/math/jpa/converter/measurement/MeasurementConverterTest.java
+++ b/math-jpa/src/test/java/io/freedriver/math/jpa/converter/measurement/MeasurementConverterTest.java
@@ -1,14 +1,14 @@
 package io.freedriver.math.jpa.converter.measurement;
 
-import io.freedriver.math.UnitPrefix;
-import io.freedriver.math.measurement.types.Measurement;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import io.freedriver.math.UnitPrefix;
+import io.freedriver.math.measurement.types.Measurement;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class MeasurementConverterTest<M extends Measurement<M>, MC extends MeasurementConverter<M>> {
 

--- a/math-jpa/src/test/java/io/freedriver/math/jpa/converter/measurement/TemporalMeasurementConverterTest.java
+++ b/math-jpa/src/test/java/io/freedriver/math/jpa/converter/measurement/TemporalMeasurementConverterTest.java
@@ -1,13 +1,13 @@
 package io.freedriver.math.jpa.converter.measurement;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigDecimal;
+
 import io.freedriver.math.TemporalUnit;
 import io.freedriver.math.UnitPrefix;
 import io.freedriver.math.measurement.types.TemporalMeasurement;
 import org.junit.jupiter.api.Test;
-
-import java.math.BigDecimal;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public abstract class TemporalMeasurementConverterTest<TM extends TemporalMeasurement<TM>, TMC extends TemporalMeasurementConverter<TM>> extends MeasurementConverterTest<TM, TMC> {
 

--- a/math/src/main/java/io/freedriver/math/TemporalUnit.java
+++ b/math/src/main/java/io/freedriver/math/TemporalUnit.java
@@ -1,7 +1,5 @@
 package io.freedriver.math;
 
-import io.freedriver.math.number.Scaled;
-
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Duration;
@@ -10,6 +8,8 @@ import java.util.Comparator;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
+
+import io.freedriver.math.number.Scaled;
 
 public enum TemporalUnit implements Scaled<TemporalUnit, Duration> {
     NANOS("Ns", "Nanoseconds", ChronoUnit.NANOS),

--- a/math/src/main/java/io/freedriver/math/UnitPrefix.java
+++ b/math/src/main/java/io/freedriver/math/UnitPrefix.java
@@ -1,15 +1,15 @@
 package io.freedriver.math;
 
+import java.math.BigDecimal;
+import java.util.*;
+import java.util.stream.Stream;
+
 import io.freedriver.math.measurement.types.electrical.Current;
 import io.freedriver.math.measurement.types.electrical.Energy;
 import io.freedriver.math.measurement.types.electrical.Potential;
 import io.freedriver.math.measurement.types.electrical.Power;
 import io.freedriver.math.number.AutoScaling;
 import io.freedriver.math.number.ScaledNumber;
-
-import java.math.BigDecimal;
-import java.util.*;
-import java.util.stream.Stream;
 
 /**
  * Class to handle metric-style unit scaling.

--- a/math/src/main/java/io/freedriver/math/measurement/types/Measurement.java
+++ b/math/src/main/java/io/freedriver/math/measurement/types/Measurement.java
@@ -1,13 +1,13 @@
 package io.freedriver.math.measurement.types;
 
+import java.util.Objects;
+
 import io.freedriver.math.UnitPrefix;
 import io.freedriver.math.measurement.units.Unit;
 import io.freedriver.math.number.NumberDelegate;
 import io.freedriver.math.number.NumberOperations;
 import io.freedriver.math.number.Scaleable;
 import io.freedriver.math.number.ScaledNumber;
-
-import java.util.Objects;
 
 /**
  * Class to handle (Instantaneous) Measurements of Power and Current.

--- a/math/src/main/java/io/freedriver/math/measurement/types/TemporalMeasurement.java
+++ b/math/src/main/java/io/freedriver/math/measurement/types/TemporalMeasurement.java
@@ -1,10 +1,10 @@
 package io.freedriver.math.measurement.types;
 
+import java.util.Objects;
+
 import io.freedriver.math.TemporalUnit;
 import io.freedriver.math.measurement.units.SIElectricalUnit;
 import io.freedriver.math.number.ScaledNumber;
-
-import java.util.Objects;
 
 public abstract class TemporalMeasurement<M extends TemporalMeasurement<M>> extends Measurement<M>  {
     private TemporalUnit temporalUnit;

--- a/math/src/main/java/io/freedriver/math/number/ScaledNumber.java
+++ b/math/src/main/java/io/freedriver/math/number/ScaledNumber.java
@@ -1,12 +1,12 @@
 package io.freedriver.math.number;
 
-import io.freedriver.math.UnitPrefix;
-
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Comparator;
 import java.util.Objects;
 import java.util.function.BiFunction;
+
+import io.freedriver.math.UnitPrefix;
 
 
 public class ScaledNumber extends Number implements NumberOperations<ScaledNumber>, Scaleable<ScaledNumber> {

--- a/math/src/test/java/io/freedriver/math/MeasurementTest.java
+++ b/math/src/test/java/io/freedriver/math/MeasurementTest.java
@@ -1,12 +1,12 @@
 package io.freedriver.math;
 
-import io.freedriver.math.measurement.types.Measurement;
-import io.freedriver.math.number.ScaledNumber;
-import org.junit.jupiter.api.Test;
-
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.stream.Stream;
+
+import io.freedriver.math.measurement.types.Measurement;
+import io.freedriver.math.number.ScaledNumber;
+import org.junit.jupiter.api.Test;
 
 public abstract class MeasurementTest<M extends Measurement<M>> extends RandomizedTest {
     public static final BigDecimal GO_ONE_LOWER = new BigDecimal("0.1");

--- a/math/src/test/java/io/freedriver/math/PowerTest.java
+++ b/math/src/test/java/io/freedriver/math/PowerTest.java
@@ -1,12 +1,12 @@
 package io.freedriver.math;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import io.freedriver.math.measurement.types.electrical.Current;
 import io.freedriver.math.measurement.types.electrical.Potential;
 import io.freedriver.math.measurement.types.electrical.Power;
 import io.freedriver.math.number.ScaledNumber;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PowerTest extends MeasurementTest<Power> {
 

--- a/math/src/test/java/io/freedriver/math/number/ScaledNumberTest.java
+++ b/math/src/test/java/io/freedriver/math/number/ScaledNumberTest.java
@@ -1,13 +1,13 @@
 package io.freedriver.math.number;
 
-import io.freedriver.math.UnitPrefix;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import io.freedriver.math.UnitPrefix;
+import org.junit.jupiter.api.Test;
 
 public class ScaledNumberTest {
 

--- a/serial-api/src/main/java/io/freedriver/serial/api/SerialPortResourceSupplier.java
+++ b/serial-api/src/main/java/io/freedriver/serial/api/SerialPortResourceSupplier.java
@@ -1,10 +1,10 @@
 package io.freedriver.serial.api;
 
-import io.freedriver.serial.api.params.SerialParams;
-
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.function.BiFunction;
+
+import io.freedriver.serial.api.params.SerialParams;
 
 public class SerialPortResourceSupplier extends SerialResourceSupplier<Path> {
     private final Path path;

--- a/serial-api/src/main/java/io/freedriver/serial/api/SerialResource.java
+++ b/serial-api/src/main/java/io/freedriver/serial/api/SerialResource.java
@@ -1,8 +1,8 @@
 package io.freedriver.serial.api;
 
-import io.freedriver.serial.api.params.SerialParams;
-
 import java.nio.file.Path;
+
+import io.freedriver.serial.api.params.SerialParams;
 
 public interface SerialResource extends AutoCloseable {
 

--- a/serial-api/src/main/java/io/freedriver/serial/api/SerialResourceSupplier.java
+++ b/serial-api/src/main/java/io/freedriver/serial/api/SerialResourceSupplier.java
@@ -1,9 +1,9 @@
 package io.freedriver.serial.api;
 
-import io.freedriver.serial.api.params.SerialParams;
-
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
+
+import io.freedriver.serial.api.params.SerialParams;
 
 public abstract class SerialResourceSupplier<X> implements Supplier<SerialResource> {
     protected abstract X input();

--- a/serial-api/src/main/java/io/freedriver/serial/stream/api/SerialEntityStream.java
+++ b/serial-api/src/main/java/io/freedriver/serial/stream/api/SerialEntityStream.java
@@ -1,11 +1,10 @@
 package io.freedriver.serial.stream.api;
 
+import java.io.ByteArrayOutputStream;
+
 import io.freedriver.base.util.EntityStreamWithOutput;
 import io.freedriver.base.util.accumulator.Accumulator;
-import io.freedriver.base.util.EntityStream;
 import io.freedriver.serial.api.SerialResource;
-
-import java.io.ByteArrayOutputStream;
 
 public class SerialEntityStream<R> extends EntityStreamWithOutput<R> {
 

--- a/serial-api/src/main/java/io/freedriver/serial/stream/api/SerialInputStream.java
+++ b/serial-api/src/main/java/io/freedriver/serial/stream/api/SerialInputStream.java
@@ -1,10 +1,10 @@
 package io.freedriver.serial.stream.api;
 
-import io.freedriver.base.util.ByteConverter;
-import io.freedriver.serial.api.SerialResource;
-
 import java.io.IOException;
 import java.io.InputStream;
+
+import io.freedriver.base.util.ByteConverter;
+import io.freedriver.serial.api.SerialResource;
 
 public class SerialInputStream extends InputStream {
     private final SerialResource resource;

--- a/serial-api/src/main/java/io/freedriver/serial/stream/api/SerialOutputStream.java
+++ b/serial-api/src/main/java/io/freedriver/serial/stream/api/SerialOutputStream.java
@@ -1,10 +1,10 @@
 package io.freedriver.serial.stream.api;
 
-import io.freedriver.base.util.ByteConverter;
-import io.freedriver.serial.api.SerialResource;
-
 import java.io.IOException;
 import java.io.OutputStream;
+
+import io.freedriver.base.util.ByteConverter;
+import io.freedriver.serial.api.SerialResource;
 
 public class SerialOutputStream extends OutputStream {
     private final SerialResource resource;

--- a/serial-api/src/test/java/io/freedriver/serial/ByteArrayBuilderTest.java
+++ b/serial-api/src/test/java/io/freedriver/serial/ByteArrayBuilderTest.java
@@ -1,10 +1,10 @@
 package io.freedriver.serial;
 
-import io.freedriver.base.util.ByteArrayBuilder;
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.freedriver.base.util.ByteArrayBuilder;
+import org.junit.jupiter.api.Test;
 
 public class ByteArrayBuilderTest {
 

--- a/serial-api/src/test/java/io/freedriver/serial/api/ByteConverterTest.java
+++ b/serial-api/src/test/java/io/freedriver/serial/api/ByteConverterTest.java
@@ -1,12 +1,12 @@
 package io.freedriver.serial.api;
 
-import io.freedriver.base.util.ByteConverter;
-import org.junit.jupiter.api.RepeatedTest;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Random;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import io.freedriver.base.util.ByteConverter;
+import org.junit.jupiter.api.RepeatedTest;
 
 public class ByteConverterTest {
     private static final int REPETITIONS = 100;

--- a/serial-api/src/test/java/io/freedriver/serial/api/EchoTest.java
+++ b/serial-api/src/test/java/io/freedriver/serial/api/EchoTest.java
@@ -1,15 +1,11 @@
 package io.freedriver.serial.api;
 
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.nio.ByteBuffer;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Random;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 public abstract class EchoTest<SR extends SerialResource> extends SerialApiTest<SR> {
 

--- a/serial-api/src/test/java/io/freedriver/serial/api/FakeEchoTest.java
+++ b/serial-api/src/test/java/io/freedriver/serial/api/FakeEchoTest.java
@@ -1,6 +1,5 @@
 package io.freedriver.serial.api;
 
-import java.nio.file.Path;
 
 public class FakeEchoTest extends EchoTest<FakeSerialResource> {
     @Override

--- a/serial-api/src/test/java/io/freedriver/serial/stream/api/StreamsEchoTest.java
+++ b/serial-api/src/test/java/io/freedriver/serial/stream/api/StreamsEchoTest.java
@@ -1,15 +1,15 @@
 package io.freedriver.serial.stream.api;
 
-import io.freedriver.serial.api.SerialApiTest;
-import io.freedriver.serial.api.SerialResource;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import io.freedriver.serial.api.SerialApiTest;
+import io.freedriver.serial.api.SerialResource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public abstract class StreamsEchoTest<SR extends SerialResource> extends SerialApiTest<SR> {
     SerialInputStream inputStream;

--- a/serial-impl/src/main/java/io/freedriver/serial/JSSCSerialResource.java
+++ b/serial-impl/src/main/java/io/freedriver/serial/JSSCSerialResource.java
@@ -1,15 +1,14 @@
 package io.freedriver.serial;
 
+import java.nio.file.Path;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import io.freedriver.serial.api.SerialResource;
 import io.freedriver.serial.api.exception.SerialResourceException;
 import io.freedriver.serial.api.params.SerialParams;
 import jssc.SerialPort;
 import jssc.SerialPortException;
-
-import java.nio.file.Path;
-import java.util.Iterator;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class JSSCSerialResource implements SerialResource {
     private static final Logger LOGGER = Logger.getLogger(JSSCSerialResource.class.getName());
@@ -94,6 +93,3 @@ public class JSSCSerialResource implements SerialResource {
         }
     }
 }
-
-
-

--- a/serial-impl/src/main/java/io/freedriver/serial/discovery/SerialDiscovery.java
+++ b/serial-impl/src/main/java/io/freedriver/serial/discovery/SerialDiscovery.java
@@ -1,10 +1,10 @@
 package io.freedriver.serial.discovery;
 
-import jssc.SerialPortList;
-
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.stream.Stream;
+
+import jssc.SerialPortList;
 
 public class SerialDiscovery {
     public static Stream<Path> getSerialDevices() {

--- a/serial-impl/src/test/java/io/freedriver/serial/EchoTestZ.java
+++ b/serial-impl/src/test/java/io/freedriver/serial/EchoTestZ.java
@@ -1,14 +1,11 @@
 package io.freedriver.serial;
 
-import io.freedriver.serial.api.SerialResource;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Random;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import io.freedriver.serial.api.SerialResource;
+import org.junit.jupiter.api.Test;
 
 // TODO : Move up to api project
 

--- a/serial-impl/src/test/java/io/freedriver/serial/JSSCEchoTest.java
+++ b/serial-impl/src/test/java/io/freedriver/serial/JSSCEchoTest.java
@@ -1,13 +1,13 @@
 package io.freedriver.serial;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import io.freedriver.base.Tests;
 import io.freedriver.serial.api.params.BaudRates;
 import io.freedriver.serial.api.params.SerialParams;
 import org.junit.jupiter.api.Tag;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 @Tag(Tests.Integration)
 public class JSSCEchoTest extends EchoTestZ<JSSCSerialResource> {

--- a/victron-jpa/src/main/java/io/freedriver/victron/jpa/FirmwareVersionConverter.java
+++ b/victron-jpa/src/main/java/io/freedriver/victron/jpa/FirmwareVersionConverter.java
@@ -1,11 +1,11 @@
 package io.freedriver.victron.jpa;
 
-import io.freedriver.victron.FirmwareVersion;
-
-import jakarta.persistence.AttributeConverter;
-import jakarta.persistence.Converter;
 import java.util.Optional;
 import java.util.logging.Logger;
+
+import io.freedriver.victron.FirmwareVersion;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
 
 @Converter(autoApply = true)
 public class FirmwareVersionConverter implements AttributeConverter<FirmwareVersion, String> {

--- a/victron/src/main/java/io/freedriver/victron/Column.java
+++ b/victron/src/main/java/io/freedriver/victron/Column.java
@@ -1,16 +1,16 @@
 package io.freedriver.victron;
 
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
 import io.freedriver.math.measurement.types.Measurement;
 import io.freedriver.math.measurement.types.electrical.Current;
 import io.freedriver.math.measurement.types.electrical.Energy;
 import io.freedriver.math.measurement.types.electrical.Potential;
 import io.freedriver.math.measurement.types.electrical.Power;
 import io.freedriver.math.number.ScaledNumber;
-
-import java.math.BigDecimal;
-import java.util.Optional;
-import java.util.function.BiConsumer;
-import java.util.function.Function;
 
 /**
  * Interface to assist in mapping VE.Direct lines to VEDirectColumnValues.

--- a/victron/src/main/java/io/freedriver/victron/VEDirectColumn.java
+++ b/victron/src/main/java/io/freedriver/victron/VEDirectColumn.java
@@ -1,13 +1,13 @@
 package io.freedriver.victron;
 
-import io.freedriver.math.number.ScaledNumber;
-import io.freedriver.victron.vedirect.OffReason;
+import static io.freedriver.math.UnitPrefix.*;
 
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import static io.freedriver.math.UnitPrefix.*;
+import io.freedriver.math.number.ScaledNumber;
+import io.freedriver.victron.vedirect.OffReason;
 
 /**
  * Known fields coming from VE.Direct serial output and how to parse them.

--- a/victron/src/main/java/io/freedriver/victron/VEDirectColumnStream.java
+++ b/victron/src/main/java/io/freedriver/victron/VEDirectColumnStream.java
@@ -1,14 +1,14 @@
 package io.freedriver.victron;
 
-import io.freedriver.serial.api.SerialResource;
-import io.freedriver.serial.stream.api.SerialEntityStream;
-import io.freedriver.base.util.accumulator.NewlineAccumulator;
-
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
+import io.freedriver.base.util.accumulator.NewlineAccumulator;
+import io.freedriver.serial.api.SerialResource;
+import io.freedriver.serial.stream.api.SerialEntityStream;
 
 /**
  * Represents a VE.Direct Device. A VE.Direct device is NOT the connected device, eg. an MPPT Charge controller.

--- a/victron/src/main/java/io/freedriver/victron/VEDirectColumnValue.java
+++ b/victron/src/main/java/io/freedriver/victron/VEDirectColumnValue.java
@@ -2,7 +2,6 @@ package io.freedriver.victron;
 
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Function;
 
 public class VEDirectColumnValue {
     private final VEDirectColumn column;

--- a/victron/src/main/java/io/freedriver/victron/VEDirectMessage.java
+++ b/victron/src/main/java/io/freedriver/victron/VEDirectMessage.java
@@ -1,15 +1,13 @@
 package io.freedriver.victron;
 
+import java.time.Instant;
+import java.util.Objects;
+
 import io.freedriver.math.measurement.types.electrical.Current;
 import io.freedriver.math.measurement.types.electrical.Energy;
 import io.freedriver.math.measurement.types.electrical.Potential;
 import io.freedriver.math.measurement.types.electrical.Power;
 import io.freedriver.victron.vedirect.OffReason;
-
-import java.time.Instant;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.function.Function;
 
 public class VEDirectMessage {
     private Instant timestamp = Instant.now();

--- a/victron/src/main/java/io/freedriver/victron/VEDirectMessageStream.java
+++ b/victron/src/main/java/io/freedriver/victron/VEDirectMessageStream.java
@@ -1,11 +1,11 @@
 package io.freedriver.victron;
 
-import io.freedriver.serial.api.SerialResource;
-
 import java.util.Iterator;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
+import io.freedriver.serial.api.SerialResource;
 
 /**
  * Represents a VE.Direct Device. A VE.Direct device is NOT the connected device, eg. an MPPT Charge controller.

--- a/victron/src/main/java/io/freedriver/victron/app/ShowDevices.java
+++ b/victron/src/main/java/io/freedriver/victron/app/ShowDevices.java
@@ -1,22 +1,17 @@
 package io.freedriver.victron.app;
 
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.stream.Stream;
+
 import io.freedriver.base.cli.ConsoleTable;
 import io.freedriver.serial.JSSCSerialResource;
 import io.freedriver.serial.api.SerialResource;
 import io.freedriver.serial.api.params.*;
 import io.freedriver.victron.VEDirectColumn;
-import io.freedriver.victron.VEDirectColumnStream;
 import io.freedriver.victron.VEDirectMessage;
 import io.freedriver.victron.VEDirectMessageStream;
-
-import java.io.IOException;
-import java.nio.file.Paths;
-import java.util.*;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class ShowDevices {
     public static void main(String[] args) throws IOException, InterruptedException {

--- a/victron/src/test/java/io/freedriver/victron/ColumnGenerator.java
+++ b/victron/src/test/java/io/freedriver/victron/ColumnGenerator.java
@@ -1,9 +1,5 @@
 package io.freedriver.victron;
 
-import io.freedriver.math.UnitPrefix;
-import io.freedriver.math.measurement.types.Measurement;
-import io.freedriver.victron.vedirect.OffReason;
-
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Optional;
@@ -12,6 +8,10 @@ import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
+
+import io.freedriver.math.UnitPrefix;
+import io.freedriver.math.measurement.types.Measurement;
+import io.freedriver.victron.vedirect.OffReason;
 
 public enum ColumnGenerator {
     PRODUCT_ID(VEDirectColumn.PRODUCT_ID, () -> randomMember(VictronProduct.values(), random()).getProductIdHex()),

--- a/victron/src/test/java/io/freedriver/victron/EnumsTest.java
+++ b/victron/src/test/java/io/freedriver/victron/EnumsTest.java
@@ -1,13 +1,13 @@
 package io.freedriver.victron;
 
-import io.freedriver.victron.vedirect.OffReason;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import io.freedriver.victron.vedirect.OffReason;
+import org.junit.jupiter.api.Test;
 
 public class EnumsTest {
 

--- a/victron/src/test/java/io/freedriver/victron/FirmwareVersionTest.java
+++ b/victron/src/test/java/io/freedriver/victron/FirmwareVersionTest.java
@@ -1,10 +1,10 @@
 package io.freedriver.victron;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.math.BigDecimal;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 public class FirmwareVersionTest {
 

--- a/victron/src/test/java/io/freedriver/victron/VEDirectReaderTest.java
+++ b/victron/src/test/java/io/freedriver/victron/VEDirectReaderTest.java
@@ -1,12 +1,12 @@
 package io.freedriver.victron;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.TestInfo;
-
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Optional;
 import java.util.logging.Logger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 
 public class VEDirectReaderTest {
     private static final Logger LOGGER = Logger.getLogger(VEDirectReaderTest.class.getName());

--- a/victron/src/test/java/io/freedriver/victron/VictronDeviceTest.java
+++ b/victron/src/test/java/io/freedriver/victron/VictronDeviceTest.java
@@ -1,6 +1,7 @@
 package io.freedriver.victron;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -8,8 +9,7 @@ import java.util.UUID;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
 
 public class VictronDeviceTest {
     private static final Logger LOGGER = Logger.getLogger(VictronDeviceTest.class.getName());


### PR DESCRIPTION
This PR applies `mvn spotless:apply` across the project to enforce the import ordering and remove unused imports that was introduced in #7 (the jakarta-migration PR).

## Changes
- Ran Spotless on all modules (base, client, daly, discovery, ee, electrodacus, genetry, genetry-kibana, jsonlink, math, math-jpa, serial-*, victron, victron-jpa, etc.)
- 135 files updated, primarily import statements reordered to: java, javax, jakarta, org, com, io
- Removes unused imports
- A few minor cleanups in formatting

This "noisy" formatting change is applied in one go so that future PRs (including any remaining jakarta updates or new features) won't be cluttered with import diffs.

All changes committed and pushed as **Yuni**.

PR created using yuni's PAT (GH_TOKEN).

See the Spotless config in root pom.xml for the rules.